### PR TITLE
Symlinks for rhythmbox and shotwell

### DIFF
--- a/Suru/16x16/apps/rhythmbox.png
+++ b/Suru/16x16/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/16x16/apps/shotwell.png
+++ b/Suru/16x16/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/16x16@2x/apps/rhythmbox.png
+++ b/Suru/16x16@2x/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/16x16@2x/apps/shotwell.png
+++ b/Suru/16x16@2x/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/24x24/apps/rhythmbox.png
+++ b/Suru/24x24/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/24x24/apps/shotwell.png
+++ b/Suru/24x24/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/24x24@2x/apps/rhythmbox.png
+++ b/Suru/24x24@2x/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/24x24@2x/apps/shotwell.png
+++ b/Suru/24x24@2x/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/256x256/apps/rhythmbox.png
+++ b/Suru/256x256/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/256x256/apps/shotwell.png
+++ b/Suru/256x256/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/256x256@2x/apps/rhythmbox.png
+++ b/Suru/256x256@2x/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/256x256@2x/apps/shotwell.png
+++ b/Suru/256x256@2x/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/32x32/apps/rhythmbox.png
+++ b/Suru/32x32/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/32x32/apps/shotwell.png
+++ b/Suru/32x32/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/32x32@2x/apps/rhythmbox.png
+++ b/Suru/32x32@2x/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/32x32@2x/apps/shotwell.png
+++ b/Suru/32x32@2x/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/48x48/apps/rhythmbox.png
+++ b/Suru/48x48/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/48x48/apps/shotwell.png
+++ b/Suru/48x48/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/Suru/48x48@2x/apps/rhythmbox.png
+++ b/Suru/48x48@2x/apps/rhythmbox.png
@@ -1,0 +1,1 @@
+music-app.png

--- a/Suru/48x48@2x/apps/shotwell.png
+++ b/Suru/48x48@2x/apps/shotwell.png
@@ -1,0 +1,1 @@
+gallery-app.png

--- a/src/symlinks/fullcolor/apps.list
+++ b/src/symlinks/fullcolor/apps.list
@@ -32,9 +32,10 @@ ebook-reader-app.png gnome-books.png
 ebook-reader-app.png org.gnome.Books.png
 error-app.png apport.png
 filemanager-app.png system-file-manager.png
-gallery-app.png gnome-photos.png 
+gallery-app.png gnome-photos.png
 gallery-app.png multimedia-photo-manager.png
 gallery-app.png org.gnome.Photos.png
+gallery-app.png shotwell.png
 games-app.png org.gnome.Games.png
 help-app.png gnome-help.png
 help-app.png help-browser.png
@@ -59,6 +60,7 @@ messaging-app.png org.gnome.Empathy.png
 music-app.png gnome-music.png
 music-app.png multimedia-audio-player.png
 music-app.png org.gnome.Music.png
+music-app.png rhythmbox.png
 notes-app.png bijiben.png
 notes-app.png org.gnome.Bijiben.png
 notes-app.png org.gnome.bijiben.png


### PR DESCRIPTION
Closes https://github.com/snwh/suru-icon-theme/issues/62
Closes https://github.com/snwh/suru-icon-theme/issues/60

- uses symlink from gallery-app for shotwell
- uses symlink from music-app for rhythmbox