### PR TITLE
Add Authenticator icon

### DIFF
--- a/src/fullcolor/apps/authenticator-app.svg
+++ b/src/fullcolor/apps/authenticator-app.svg
@@ -1,0 +1,1030 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:osb="http://www.openswatchbook.org/uri/2009/osb"
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   inkscape:export-ydpi="90.000000"
+   inkscape:export-xdpi="90.000000"
+   width="400"
+   height="300"
+   id="svg11300"
+   sodipodi:version="0.32"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="authenticator-app.svg"
+   inkscape:output_extension="org.inkscape.output.svg.inkscape"
+   version="1.0"
+   style="display:inline;enable-background:new"
+   inkscape:export-filename="/home/sam/suru-template.png">
+  <title
+     id="title3004">Suru Icon Theme Template</title>
+  <sodipodi:namedview
+     stroke="#ef2929"
+     fill="#f57900"
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25490196"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="180.45662"
+     inkscape:cy="116.07965"
+     inkscape:current-layer="layer7"
+     showgrid="false"
+     inkscape:grid-bbox="true"
+     inkscape:document-units="px"
+     inkscape:showpageshadow="false"
+     inkscape:window-width="1296"
+     inkscape:window-height="704"
+     inkscape:window-x="70"
+     inkscape:window-y="27"
+     width="400px"
+     height="300px"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     gridtolerance="10000"
+     inkscape:object-nodes="true"
+     inkscape:snap-grids="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-maximized="1"
+     inkscape:bbox-paths="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-global="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:pagecheckerboard="false"
+     showborder="false"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true">
+    <inkscape:grid
+       spacingy="1"
+       spacingx="1"
+       id="grid5883"
+       type="xygrid"
+       enabled="true"
+       visible="true"
+       empspacing="4"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid11592"
+       empspacing="2"
+       visible="true"
+       enabled="false"
+       spacingx="0.5"
+       spacingy="0.5"
+       color="#ff0000"
+       opacity="0.1254902"
+       empcolor="#ff0000"
+       empopacity="0.25098039"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0" />
+  </sodipodi:namedview>
+  <defs
+     id="defs3">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient927">
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0"
+         id="stop923" />
+      <stop
+         id="stop933"
+         offset="0.125"
+         style="stop-color:#ffffff;stop-opacity:0.09803922" />
+      <stop
+         id="stop931"
+         offset="0.92500001"
+         style="stop-color:#ffffff;stop-opacity:0.09803922" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.49803922"
+         offset="1"
+         id="stop925" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9430">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path9432"
+         d="m 166.0625,-196 h 179.875 C 491.2348,-196 512,-175.28677 512,-30.125 v 148.25 C 512,263.28618 491.2348,284 345.9375,284 H 166.0625 C 20.7652,284 0,263.28618 0,118.125 V -30.125 C 0,-175.28677 20.7652,-196 166.0625,-196 Z"
+         style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient929"
+       x1="168"
+       y1="239"
+       x2="168"
+       y2="279"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,512,-175)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient965"
+       x1="112"
+       y1="255"
+       x2="112"
+       y2="281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,448,-120)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient1006"
+       x1="64"
+       y1="263"
+       x2="64"
+       y2="281"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(-1,0,0,1,396,-72)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient927"
+       id="linearGradient1045"
+       x1="760"
+       y1="254"
+       x2="760"
+       y2="265"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-432,-16)" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       xlink:href="#linearGradient3881"
+       id="linearGradient3198"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.3333337,0,0,1.3636363,290.99999,71.52273)"
+       x1="24"
+       y1="14"
+       x2="24"
+       y2="33" />
+    <linearGradient
+       id="linearGradient3881">
+      <stop
+         id="stop3883"
+         offset="0"
+         style="stop-color:#2d2d2d;stop-opacity:1" />
+      <stop
+         id="stop3885"
+         offset="1"
+         style="stop-color:#3f3f3f;stop-opacity:1" />
+    </linearGradient>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter974"
+       x="-0.0232"
+       width="1.0464"
+       y="-0.024857143"
+       height="1.0497143">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="2.32"
+         id="feGaussianBlur976" />
+    </filter>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient1013"
+       id="linearGradient1108"
+       x1="296"
+       y1="-212"
+       x2="296"
+       y2="236"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient1013"
+       inkscape:collect="always">
+      <stop
+         id="stop1005"
+         offset="0"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:0.09803922"
+         offset="0.125"
+         id="stop1007" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0.09803922"
+         offset="0.92500001"
+         id="stop1009" />
+      <stop
+         id="stop1011"
+         offset="1"
+         style="stop-color:#000000;stop-opacity:0.49803922" />
+    </linearGradient>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1082-3">
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1084-6"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:1;fill:#8c59d9;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1119">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#dfdfdf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 174.44531,214.99998 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.49999 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+         id="path1121"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas" />
+    </clipPath>
+    <linearGradient
+       id="linearGradient3045">
+      <stop
+         id="stop3047"
+         offset="0"
+         style="stop-color:#847784;stop-opacity:0.99607843" />
+      <stop
+         id="stop3049"
+         offset="1"
+         style="stop-color:#695f69;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4213">
+      <stop
+         style="stop-color:#b1d7f3;stop-opacity:1"
+         offset="0"
+         id="stop4215" />
+      <stop
+         style="stop-color:#8fafda;stop-opacity:1"
+         offset="1"
+         id="stop4217" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="gradient"
+       id="linearGradient5460">
+      <stop
+         id="stop5462"
+         offset="0"
+         style="stop-color:#e6e6e6;stop-opacity:1" />
+      <stop
+         id="stop5464"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       osb:paint="solid"
+       id="linearGradient5476">
+      <stop
+         id="stop5478"
+         offset="0"
+         style="stop-color:#772953;stop-opacity:1;" />
+    </linearGradient>
+    <filter
+       color-interpolation-filters="sRGB"
+       id="filter4154">
+      <feComposite
+         operator="arithmetic"
+         k4="0"
+         result="composite1"
+         k1="0"
+         k2="1"
+         k3="0"
+         in2="SourceGraphic"
+         id="feComposite4156" />
+      <feColorMatrix
+         in="composite1"
+         result="colormatrix1"
+         values="0"
+         type="saturate"
+         id="feColorMatrix4158" />
+      <feFlood
+         flood-color="rgb(72,59,72)"
+         result="flood1"
+         id="feFlood4160" />
+      <feBlend
+         in="flood1"
+         in2="colormatrix1"
+         mode="multiply"
+         result="blend1"
+         id="feBlend4162" />
+      <feBlend
+         result="blend2"
+         in2="blend1"
+         mode="screen"
+         id="feBlend4164" />
+      <feColorMatrix
+         in="blend2"
+         result="colormatrix2"
+         values="1"
+         type="saturate"
+         id="feColorMatrix4166" />
+      <feComposite
+         in="colormatrix2"
+         in2="SourceGraphic"
+         result="composite2"
+         operator="in"
+         id="feComposite4168" />
+    </filter>
+    <clipPath
+       id="clipPath3062"
+       clipPathUnits="userSpaceOnUse">
+      <rect
+         y="-194.96773"
+         x="34.167744"
+         height="445.93549"
+         width="475.66452"
+         id="rect3064"
+         style="color:#000000;fill:url(#linearGradient3066);fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:40;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:new" />
+    </clipPath>
+    <linearGradient
+       y2="288"
+       x2="256"
+       y1="50"
+       x1="256"
+       gradientTransform="matrix(1.8580645,0,0,1.8736786,4.4387126,-288.65166)"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient3066"
+       xlink:href="#linearGradient3045"
+       inkscape:collect="always" />
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1157"
+       x="-0.087750606"
+       width="1.1755012"
+       y="-0.14039844"
+       height="1.2807969">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.58500405"
+         id="feGaussianBlur1159" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1138"
+       x="-0.019500135"
+       width="1.0390003"
+       y="-0.031199655"
+       height="1.0623993">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.1300009"
+         id="feGaussianBlur1140" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1119-9">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#dfdfdf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 174.44531,214.99998 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.49999 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+         id="path1121-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas" />
+    </clipPath>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1157-3"
+       x="-0.087750606"
+       width="1.1755012"
+       y="-0.14039844"
+       height="1.2807969">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.58500405"
+         id="feGaussianBlur1159-6" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1138-7"
+       x="-0.019500135"
+       width="1.0390003"
+       y="-0.031199655"
+       height="1.0623993">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.1300009"
+         id="feGaussianBlur1140-5" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1119-9-3">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#dfdfdf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 174.44531,214.99998 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.49999 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+         id="path1121-2-5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas" />
+    </clipPath>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1157-3-3"
+       x="-0.087750606"
+       width="1.1755012"
+       y="-0.14039844"
+       height="1.2807969">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.58500405"
+         id="feGaussianBlur1159-6-6" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1138-7-1"
+       x="-0.019500135"
+       width="1.0390003"
+       y="-0.031199655"
+       height="1.0623993">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.1300009"
+         id="feGaussianBlur1140-5-2" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1119-9-3-9">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#dfdfdf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 174.44531,214.99998 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.49999 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+         id="path1121-2-5-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas" />
+    </clipPath>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1157-3-3-2"
+       x="-0.087750606"
+       width="1.1755012"
+       y="-0.14039844"
+       height="1.2807969">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.58500405"
+         id="feGaussianBlur1159-6-6-5" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1138-7-1-4"
+       x="-0.019500135"
+       width="1.0390003"
+       y="-0.031199655"
+       height="1.0623993">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.1300009"
+         id="feGaussianBlur1140-5-2-7" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1119-9-3-9-4">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#dfdfdf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 174.44531,214.99998 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.49999 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+         id="path1121-2-5-3-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas" />
+    </clipPath>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1157-3-3-2-7"
+       x="-0.087750606"
+       width="1.1755012"
+       y="-0.14039844"
+       height="1.2807969">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.58500405"
+         id="feGaussianBlur1159-6-6-5-2" />
+    </filter>
+    <filter
+       inkscape:collect="always"
+       style="color-interpolation-filters:sRGB"
+       id="filter1138-7-1-4-2"
+       x="-0.019500135"
+       width="1.0390003"
+       y="-0.031199655"
+       height="1.0623993">
+      <feGaussianBlur
+         inkscape:collect="always"
+         stdDeviation="0.1300009"
+         id="feGaussianBlur1140-5-2-7-6" />
+    </filter>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath1119-9-3-9-4-1">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#dfdfdf;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 174.44531,214.99998 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.49999 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+         id="path1121-2-5-3-4-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas" />
+    </clipPath>
+  </defs>
+  <metadata
+     id="metadata4">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Sam Hewitt</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:source />
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:title>Suru Icon Theme Template</dc:title>
+        <dc:subject>
+          <rdf:Bag />
+        </dc:subject>
+        <dc:date />
+        <dc:rights>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:rights>
+        <dc:publisher>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:publisher>
+        <dc:identifier />
+        <dc:relation />
+        <dc:language />
+        <dc:coverage />
+        <dc:description />
+        <dc:contributor>
+          <cc:Agent>
+            <dc:title />
+          </cc:Agent>
+        </dc:contributor>
+      </cc:Work>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     style="display:inline"
+     inkscape:groupmode="layer"
+     inkscape:label="Icon"
+     id="layer1">
+    <g
+       style="display:none"
+       inkscape:label="Baseplate"
+       id="layer7"
+       inkscape:groupmode="layer">
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="19.006836"
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans';display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="context"
+         id="context"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans'"
+           y="-8.2548828"
+           x="19.006836"
+           sodipodi:role="line"
+           id="tspan3933">apps</tspan></text>
+      <text
+         y="-8.2548828"
+         xml:space="preserve"
+         x="146.48828"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;line-height:0%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold';text-align:start;writing-mode:lr-tb;text-anchor:start;display:inline;fill:#000000;fill-opacity:1;stroke:none;enable-background:new"
+         inkscape:label="icon-name"
+         id="icon-name"><tspan
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:18px;line-height:1.25;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans Bold'"
+           y="-8.2548828"
+           x="146.48828"
+           sodipodi:role="line"
+           id="tspan3937">authenticator-app</tspan></text>
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect16x16"
+         width="16"
+         height="16"
+         x="320"
+         y="236"
+         inkscape:label="16x16" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect24x24"
+         width="24"
+         height="24"
+         x="320"
+         y="188"
+         inkscape:label="24x24" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect32x32"
+         width="32"
+         height="32"
+         x="320"
+         y="132"
+         inkscape:label="32x32" />
+      <rect
+         inkscape:label="48x48"
+         y="60"
+         x="320"
+         height="48"
+         width="48"
+         id="rect48x48"
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate" />
+      <rect
+         style="display:inline;overflow:visible;visibility:visible;fill:#cdcdcd;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2;marker:none;enable-background:accumulate"
+         id="rect3951"
+         width="256"
+         height="256"
+         x="24"
+         y="28"
+         inkscape:label="48x48" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer4"
+       inkscape:label="Shadows"
+       style="display:inline">
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 351.93164,63 c 6.83457,0 10.87325,0.44856 13.24609,2.81836 C 367.55058,68.18816 368,72.22248 368,79.05078 v 11.89844 c 0,6.82827 -0.44942,10.86261 -2.82227,13.23242 C 362.80489,106.55145 358.76621,107 351.93164,107 h -15.86328 c -6.83457,0 -10.87325,-0.44855 -13.24609,-2.81836 C 320.44942,101.81183 320,97.77749 320,90.94922 V 79.05078 c 0,-6.8283 0.44942,-10.86262 2.82227,-13.23242 C 325.19511,63.44856 329.23379,63 336.06836,63 Z"
+         id="path907"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsscsscsscss" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 341.12109,134 c 4.56431,0 7.30422,0.28679 8.94727,1.92773 1.64305,1.64095 1.93164,4.37931 1.93164,8.93946 v 8.26562 c 0,4.56013 -0.28859,7.29851 -1.93164,8.93946 C 348.42531,163.71321 345.6854,164 341.12109,164 h -10.24218 c -4.5643,0 -7.30422,-0.28679 -8.94727,-1.92773 C 320.28859,160.43132 320,157.69294 320,153.13281 v -8.26562 c 0,-4.56015 0.28859,-7.29851 1.93164,-8.93946 C 323.57469,134.28679 326.31461,134 330.87891,134 Z"
+         id="path1011"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scsscsscsscss" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 335.71484,190 c 3.42917,1e-5 5.52264,0.20591 6.80078,1.48242 1.27815,1.27651 1.48438,3.3669 1.48438,6.79297 v 5.44922 c 0,3.42606 -0.20623,5.51645 -1.48438,6.79297 C 341.23748,211.79409 339.14401,212 335.71484,212 h -7.42968 c -3.42917,0 -5.52263,-0.20591 -6.80079,-1.48242 C 320.20622,209.24106 320,207.15067 320,203.72461 v -5.44922 c 0,-3.42607 0.20622,-5.51646 1.48437,-6.79297 1.27816,-1.27651 3.37162,-1.48243 6.80079,-1.48242 z"
+         id="path1013"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cssscsscssscc" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:new"
+         d="m 325.68945,237 c -2.29403,0 -3.73713,0.12503 -4.65039,1.03711 C 320.12581,238.94919 320,240.3916 320,242.68359 v 3.63282 c 0,2.29198 0.12581,3.7344 1.03906,4.64648 0.91325,0.91208 2.35637,1.03711 4.65039,1.03711 h 4.6211 c 2.29403,0 3.73713,-0.12503 4.65039,-1.03711 0.91325,-0.91208 1.03906,-2.3545 1.03906,-4.64648 v -3.63282 c 0,-2.29199 -0.12581,-3.7344 -1.03906,-4.64648 C 334.04768,237.12503 332.60458,237 330.31055,237 Z"
+         id="path1050"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="scssssscsscss" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path4567"
+         d="m 188.96876,45.999995 c 72.64865,0 83.03125,10.356615 83.03125,82.937505 v 58.125 c 0,72.58059 -10.3826,82.9375 -83.03125,82.9375 h -73.9375 C 42.382606,270 32.000006,259.64309 32.000006,187.0625 v -58.125 c 0,-72.58089 10.3826,-82.937505 83.031254,-82.937505 z"
+         style="display:inline;opacity:0.2;fill:#000000;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;filter:url(#filter974);enable-background:new" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="Shape"
+       style="display:inline">
+      <path
+         style="opacity:1;fill:#c8c4b7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 188.96875,44.000001 C 261.6174,44.000001 272,54.356616 272,126.9375 v 58.125 C 272,257.64309 261.6174,268 188.96875,268 h -73.9375 C 42.3826,268 32,257.64309 32,185.0625 v -58.125 C 32,54.356616 42.3826,44.000001 115.03125,44.000001 Z"
+         id="rect877"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 32,156 v 29.0625 C 32,257.64309 42.3826,268 115.03125,268 h 73.9375 C 261.6174,268 272,257.64309 272,185.0625 V 156 Z"
+         id="path932"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path888"
+         d="M 351.93164,62.5 C 365.55326,62.5 367.5,64.44187 367.5,78.05078 V 89.94922 C 367.5,103.55808 365.55326,105.5 351.93164,105.5 H 336.06836 C 322.44674,105.5 320.5,103.55808 320.5,89.94922 V 78.05078 C 320.5,64.44187 322.44674,62.5 336.06836,62.5 Z"
+         style="opacity:1;fill:#c8c4b7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path942"
+         d="m 341.12109,133.5 c 9.08109,0 10.37891,1.29458 10.37891,10.36719 v 8.26562 c 0,9.07258 -1.29782,10.36719 -10.37891,10.36719 H 330.87891 C 321.79783,162.5 320.5,161.20539 320.5,152.13281 v -8.26562 c 0,-9.07261 1.29783,-10.36719 10.37891,-10.36719 z"
+         style="opacity:1;fill:#c8c4b7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <path
+         style="opacity:1;fill:#c8c4b7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 330.31054,236.5 c 4.54055,0 5.18946,0.64729 5.18946,5.18359 v 3.63282 c 0,4.53629 -0.64891,5.18359 -5.18946,5.18359 h -4.62109 c -4.54053,0 -5.18945,-0.6473 -5.18945,-5.18359 v -3.63282 c 0,-4.5363 0.64892,-5.18359 5.18946,-5.18359 z"
+         id="path946"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="opacity:1;fill:#c8c4b7;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 335.71582,210.49999 c 6.81081,-1e-5 7.78418,-0.97093 7.78418,-7.77539 v -5.44891 c 0,-6.80444 -0.97337,-7.77539 -7.78418,-7.77539 h -7.43164 c -6.81081,0 -7.78418,0.97095 -7.78418,7.77539 v 5.44892 c 0,6.80446 0.97337,7.7754 7.78418,7.77539 z"
+         id="path948"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 320.5,148 v 4.13281 c 0,9.07258 1.29783,10.36719 10.37891,10.36719 h 10.24218 c 9.08109,0 10.37891,-1.29461 10.37891,-10.36719 V 148 Z"
+         id="path1085"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 320.5,84 v 5.949219 C 320.5,103.55808 322.44674,105.5 336.06836,105.5 h 15.86328 C 365.55326,105.5 367.5,103.55808 367.5,89.949219 V 84 Z"
+         id="path1135"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 320.5,200 v 2.72461 c 0,6.80446 0.97435,7.7754 7.78516,7.77539 h 7.42968 c 6.81081,-1e-5 7.78516,-0.97093 7.78516,-7.77539 V 200 Z"
+         id="path1246"
+         inkscape:connector-curvature="0" />
+      <path
+         style="opacity:0.2;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 320.5,243 v 2.31641 c 0,4.53629 0.64892,5.18359 5.18945,5.18359 h 4.6211 c 4.54055,0 5.18945,-0.6473 5.18945,-5.18359 V 243 Z"
+         id="path985"
+         inkscape:connector-curvature="0" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1068"
+         d="M 361.9375,-212 C 507.2348,-212 528,-191.28677 528,-46.125 V 70.125 C 528,215.28618 507.2348,236 361.9375,236 H 214.0625 C 68.7652,236 48,215.28618 48,70.125 V -46.125 C 48,-191.28677 68.7652,-212 214.0625,-212 Z"
+         style="display:inline;opacity:0.4;fill:none;fill-opacity:1;stroke:url(#linearGradient1108);stroke-width:8;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         clip-path="url(#clipPath1082-3)"
+         transform="matrix(0.5,0,0,0.5,8,150)" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer6"
+       inkscape:label="Pictogram"
+       style="display:inline">
+      <g
+         id="g1341"
+         transform="matrix(1.0788128,0,0,1.0788128,-27.420753,-21.96812)">
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-0"
+           d="m 174.44341,215.16112 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z m 0.55469,6.00002 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1157);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-7"
+           d="m 174.44531,215.1074 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221.10742 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1138);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333"
+           d="m 114.48191,118.31373 c -4.84414,0 -8.75734,0.44402 -12.14471,1.78174 -3.386433,1.33745 -6.16344,3.82086 -7.744954,6.83589 -3.16303,6.03005 -2.767326,13.05592 -2.872512,22.63493 v 0.0372 30.50714 0.0372 c 0.111702,9.57863 -0.288564,16.60497 2.872512,22.63493 1.580584,3.01493 4.358614,5.49834 7.744954,6.83588 3.38746,1.33763 7.30057,1.78174 12.14471,1.78174 h 28.96183 c 4.84415,0 8.75828,-0.44401 12.14472,-1.78174 3.38736,-1.33744 6.14528,-3.82086 7.7268,-6.83588 2.74945,-5.24171 2.76183,-11.5566 2.79981,-19.32604 l 18.10793,-0.0372 5.23603,-4.5997 4.65425,4.65425 4.65426,-4.65425 4.65425,4.65425 4.65425,-4.65425 9.3085,9.3085 23.27127,-23.27126 -18.61701,-18.61701 -55.92373,0.0186 c -0.0372,-7.76925 -0.0558,-14.08442 -2.79981,-19.32604 -1.58058,-3.01502 -4.35861,-5.49835 -7.74496,-6.83589 -3.38745,-1.33893 -7.28241,-1.78304 -12.12656,-1.78304 z m 5.16334,55.85122 c -5.1409,0 -9.3086,-4.92057 -9.30851,-9.3087 10e-5,-4.38802 4.16761,-9.30822 9.30851,-9.30822 5.1409,0 9.30841,4.9202 9.3085,9.30822 10e-5,4.38813 -4.1676,9.3087 -9.3085,9.3087 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:37.23401642;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           clip-path="url(#clipPath1119-9)"
+           y="220.00009"
+           x="172"
+           height="5.0000877"
+           width="16"
+           id="rect1079"
+           style="display:inline;opacity:0.06000001;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#888888;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+      </g>
+      <g
+         style="display:inline;enable-background:new"
+         id="g1341-6"
+         transform="matrix(0.20223252,0,0,0.20223252,310.36074,50.633049)">
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-0-2"
+           d="m 174.44341,215.16112 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z m 0.55469,6.00002 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1157-3);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-7-9"
+           d="m 174.44531,215.1074 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221.10742 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1138-7);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-1"
+           d="m 114.48191,118.31373 c -4.84414,0 -8.75734,0.44402 -12.14471,1.78174 -3.386433,1.33745 -6.16344,3.82086 -7.744954,6.83589 -3.16303,6.03005 -2.767326,13.05592 -2.872512,22.63493 v 0.0372 30.50714 0.0372 c 0.111702,9.57863 -0.288564,16.60497 2.872512,22.63493 1.580584,3.01493 4.358614,5.49834 7.744954,6.83588 3.38746,1.33763 7.30057,1.78174 12.14471,1.78174 h 28.96183 c 4.84415,0 8.75828,-0.44401 12.14472,-1.78174 3.38736,-1.33744 6.14528,-3.82086 7.7268,-6.83588 2.74945,-5.24171 2.76183,-11.5566 2.79981,-19.32604 l 18.10793,-0.0372 5.23603,-4.5997 4.65425,4.65425 4.65426,-4.65425 4.65425,4.65425 4.65425,-4.65425 9.3085,9.3085 23.27127,-23.27126 -18.61701,-18.61701 -55.92373,0.0186 c -0.0372,-7.76925 -0.0558,-14.08442 -2.79981,-19.32604 -1.58058,-3.01502 -4.35861,-5.49835 -7.74496,-6.83589 -3.38745,-1.33893 -7.28241,-1.78304 -12.12656,-1.78304 z m 5.16334,55.85122 c -5.1409,0 -9.3086,-4.92057 -9.30851,-9.3087 10e-5,-4.38802 4.16761,-9.30822 9.30851,-9.30822 5.1409,0 9.30841,4.9202 9.3085,9.30822 10e-5,4.38813 -4.1676,9.3087 -9.3085,9.3087 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:37.23401642;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           clip-path="url(#clipPath1119-9-3)"
+           y="220.00009"
+           x="172"
+           height="5.0000877"
+           width="16"
+           id="rect1079-2"
+           style="display:inline;opacity:0.06000001;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#888888;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+      </g>
+      <g
+         style="display:inline;enable-background:new"
+         id="g1341-6-1"
+         transform="matrix(0.13412223,0,0,0.13412223,313.61151,125.78776)">
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-0-2-9"
+           d="m 174.44341,215.16112 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z m 0.55469,6.00002 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1157-3-3);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-7-9-4"
+           d="m 174.44531,215.1074 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221.10742 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1138-7-1);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-1-7"
+           d="m 114.48191,118.31373 c -4.84414,0 -8.75734,0.44402 -12.14471,1.78174 -3.386433,1.33745 -6.16344,3.82086 -7.744954,6.83589 -3.16303,6.03005 -2.767326,13.05592 -2.872512,22.63493 v 0.0372 30.50714 0.0372 c 0.111702,9.57863 -0.288564,16.60497 2.872512,22.63493 1.580584,3.01493 4.358614,5.49834 7.744954,6.83588 3.38746,1.33763 7.30057,1.78174 12.14471,1.78174 h 28.96183 c 4.84415,0 8.75828,-0.44401 12.14472,-1.78174 3.38736,-1.33744 6.14528,-3.82086 7.7268,-6.83588 2.74945,-5.24171 2.76183,-11.5566 2.79981,-19.32604 l 18.10793,-0.0372 5.23603,-4.5997 4.65425,4.65425 4.65426,-4.65425 4.65425,4.65425 4.65425,-4.65425 9.3085,9.3085 23.27127,-23.27126 -18.61701,-18.61701 -55.92373,0.0186 c -0.0372,-7.76925 -0.0558,-14.08442 -2.79981,-19.32604 -1.58058,-3.01502 -4.35861,-5.49835 -7.74496,-6.83589 -3.38745,-1.33893 -7.28241,-1.78304 -12.12656,-1.78304 z m 5.16334,55.85122 c -5.1409,0 -9.3086,-4.92057 -9.30851,-9.3087 10e-5,-4.38802 4.16761,-9.30822 9.30851,-9.30822 5.1409,0 9.30841,4.9202 9.3085,9.30822 10e-5,4.38813 -4.1676,9.3087 -9.3085,9.3087 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:37.23401642;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           clip-path="url(#clipPath1119-9-3-9)"
+           y="220.00009"
+           x="172"
+           height="5.0000877"
+           width="16"
+           id="rect1079-2-8"
+           style="display:inline;opacity:0.06000001;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#888888;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+      </g>
+      <g
+         style="display:inline;enable-background:new"
+         id="g1341-6-1-3"
+         transform="matrix(0.1010689,0,0,0.1010689,315.18263,183.31872)">
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-0-2-9-0"
+           d="m 174.44341,215.16112 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z m 0.55469,6.00002 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1157-3-3-2);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-7-9-4-7"
+           d="m 174.44531,215.1074 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221.10742 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1138-7-1-4);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-1-7-8"
+           d="m 114.48191,118.31373 c -4.84414,0 -8.75734,0.44402 -12.14471,1.78174 -3.386433,1.33745 -6.16344,3.82086 -7.744954,6.83589 -3.16303,6.03005 -2.767326,13.05592 -2.872512,22.63493 v 0.0372 30.50714 0.0372 c 0.111702,9.57863 -0.288564,16.60497 2.872512,22.63493 1.580584,3.01493 4.358614,5.49834 7.744954,6.83588 3.38746,1.33763 7.30057,1.78174 12.14471,1.78174 h 28.96183 c 4.84415,0 8.75828,-0.44401 12.14472,-1.78174 3.38736,-1.33744 6.14528,-3.82086 7.7268,-6.83588 2.74945,-5.24171 2.76183,-11.5566 2.79981,-19.32604 l 18.10793,-0.0372 5.23603,-4.5997 4.65425,4.65425 4.65426,-4.65425 4.65425,4.65425 4.65425,-4.65425 9.3085,9.3085 23.27127,-23.27126 -18.61701,-18.61701 -55.92373,0.0186 c -0.0372,-7.76925 -0.0558,-14.08442 -2.79981,-19.32604 -1.58058,-3.01502 -4.35861,-5.49835 -7.74496,-6.83589 -3.38745,-1.33893 -7.28241,-1.78304 -12.12656,-1.78304 z m 5.16334,55.85122 c -5.1409,0 -9.3086,-4.92057 -9.30851,-9.3087 10e-5,-4.38802 4.16761,-9.30822 9.30851,-9.30822 5.1409,0 9.30841,4.9202 9.3085,9.30822 10e-5,4.38813 -4.1676,9.3087 -9.3085,9.3087 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:37.23401642;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           clip-path="url(#clipPath1119-9-3-9-4)"
+           y="220.00009"
+           x="172"
+           height="5.0000877"
+           width="16"
+           id="rect1079-2-8-6"
+           style="display:inline;opacity:0.06000001;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#888888;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+      </g>
+      <g
+         style="display:inline;enable-background:new"
+         id="g1341-6-1-3-6"
+         transform="matrix(0.06737927,0,0,0.06737927,316.78842,232.36721)">
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-0-2-9-0-1"
+           d="m 174.44341,215.16112 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z m 0.55469,6.00002 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.2;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1157-3-3-2-7);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-7-9-4-7-5"
+           d="m 174.44531,215.1074 c -0.5204,0 -0.94079,0.0477 -1.30469,0.19141 -0.3638,0.14368 -0.66213,0.41047 -0.83203,0.73437 -0.3398,0.6478 -0.29729,1.40258 -0.30859,2.43164 v 0.004 3.27734 0.004 c 0.012,1.02902 -0.031,1.78385 0.30859,2.43164 0.1698,0.32389 0.46824,0.59068 0.83203,0.73437 0.36391,0.1437 0.78429,0.19141 1.30469,0.19141 h 3.11133 c 0.5204,0 0.94089,-0.0477 1.30469,-0.19141 0.3639,-0.14368 0.66018,-0.41047 0.83008,-0.73437 0.29537,-0.56311 0.2967,-1.24151 0.30078,-2.07617 l 1.94531,-0.004 0.5625,-0.49414 0.5,0.5 0.5,-0.5 0.5,0.5 0.5,-0.5 1,1 2.5,-2.5 -2,-2 -6.00781,0.002 c -0.004,-0.83464 -0.006,-1.51307 -0.30078,-2.07617 -0.1698,-0.3239 -0.46824,-0.59068 -0.83203,-0.73437 -0.36391,-0.14384 -0.78234,-0.19155 -1.30274,-0.19155 z M 175,221.10742 c -0.55228,0 -1.00001,-0.52861 -1,-1.00002 1e-5,-0.4714 0.44772,-0.99997 1,-0.99997 0.55228,0 0.99999,0.52857 1,0.99997 1e-5,0.47141 -0.44772,1.00002 -1,1.00002 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:3.99999976;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;filter:url(#filter1138-7-1-4-2);color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+        <path
+           sodipodi:nodetypes="scsccccccsscccccccccccccccsssasas"
+           inkscape:connector-curvature="0"
+           id="path5333-1-7-8-9"
+           d="m 114.48191,118.31373 c -4.84414,0 -8.75734,0.44402 -12.14471,1.78174 -3.386433,1.33745 -6.16344,3.82086 -7.744954,6.83589 -3.16303,6.03005 -2.767326,13.05592 -2.872512,22.63493 v 0.0372 30.50714 0.0372 c 0.111702,9.57863 -0.288564,16.60497 2.872512,22.63493 1.580584,3.01493 4.358614,5.49834 7.744954,6.83588 3.38746,1.33763 7.30057,1.78174 12.14471,1.78174 h 28.96183 c 4.84415,0 8.75828,-0.44401 12.14472,-1.78174 3.38736,-1.33744 6.14528,-3.82086 7.7268,-6.83588 2.74945,-5.24171 2.76183,-11.5566 2.79981,-19.32604 l 18.10793,-0.0372 5.23603,-4.5997 4.65425,4.65425 4.65426,-4.65425 4.65425,4.65425 4.65425,-4.65425 9.3085,9.3085 23.27127,-23.27126 -18.61701,-18.61701 -55.92373,0.0186 c -0.0372,-7.76925 -0.0558,-14.08442 -2.79981,-19.32604 -1.58058,-3.01502 -4.35861,-5.49835 -7.74496,-6.83589 -3.38745,-1.33893 -7.28241,-1.78304 -12.12656,-1.78304 z m 5.16334,55.85122 c -5.1409,0 -9.3086,-4.92057 -9.30851,-9.3087 10e-5,-4.38802 4.16761,-9.30822 9.30851,-9.30822 5.1409,0 9.30841,4.9202 9.3085,9.30822 10e-5,4.38813 -4.1676,9.3087 -9.3085,9.3087 z"
+           style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#f7f7f7;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:37.23401642;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <rect
+           clip-path="url(#clipPath1119-9-3-9-4-1)"
+           y="220.00009"
+           x="172"
+           height="5.0000877"
+           width="16"
+           id="rect1079-2-8-6-4"
+           style="display:inline;opacity:0.06000001;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:#888888;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+           transform="matrix(9.3085047,0,0,9.3085047,-1509.3431,-1883.0148)" />
+      </g>
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer5"
+       inkscape:label="Border"
+       style="display:inline">
+      <path
+         style="display:inline;opacity:0.4;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="m 341.12109,133.5 c 9.08109,0 10.37891,1.29458 10.37891,10.36719 v 8.26562 c 0,9.07258 -1.29782,10.36719 -10.37891,10.36719 H 330.87891 C 321.79783,162.5 320.5,161.20539 320.5,152.13281 v -8.26562 c 0,-9.07261 1.29783,-10.36719 10.37891,-10.36719 z"
+         id="path950"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         style="display:inline;opacity:0.4;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new"
+         d="M 351.93164,62.5 C 365.55326,62.5 367.5,64.44187 367.5,78.05078 V 89.94922 C 367.5,103.55808 365.55326,105.5 351.93164,105.5 H 336.06836 C 322.44674,105.5 320.5,103.55808 320.5,89.94922 V 78.05078 C 320.5,64.44187 322.44674,62.5 336.06836,62.5 Z"
+         id="path892"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssss" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path970"
+         d="m 335.71582,189.50031 c 6.81081,10e-6 7.78418,0.97093 7.78418,7.77539 v 5.44891 c 0,6.80444 -0.97337,7.77539 -7.78418,7.77539 h -7.43164 c -6.81081,0 -7.78418,-0.97095 -7.78418,-7.77539 v -5.44892 c 0,-6.80446 0.97337,-7.7754 7.78418,-7.77539 z"
+         style="display:inline;opacity:0.4;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+      <path
+         sodipodi:nodetypes="sssssssss"
+         inkscape:connector-curvature="0"
+         id="path1025"
+         d="m 330.31054,236.5 c 4.54055,0 5.18946,0.64729 5.18946,5.18359 v 3.63282 c 0,4.53629 -0.64891,5.18359 -5.18946,5.18359 h -4.62109 c -4.54053,0 -5.18945,-0.6473 -5.18945,-5.18359 v -3.63282 c 0,-4.5363 0.64892,-5.18359 5.18946,-5.18359 z"
+         style="display:inline;opacity:0.4;fill:none;fill-opacity:1;stroke:#000000;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;enable-background:new" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient929);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 351.93164,63.5 h -15.86328 c -6.76329,0 -10.36307,0.55877 -12.18555,2.37891 -1.82247,1.82013 -2.38281,5.4151 -2.38281,12.17187 v 11.89844 c 0,6.75675 0.56034,10.35173 2.38281,12.17187 1.82248,1.82015 5.42226,2.37891 12.18555,2.37891 h 15.86328 c 6.76329,0 10.36307,-0.55876 12.18555,-2.37891 C 365.93966,100.30095 366.5,96.70597 366.5,89.94922 V 78.05078 c 0,-6.75677 -0.56034,-10.35174 -2.38281,-12.17187 C 362.29471,64.05877 358.69493,63.5 351.93164,63.5 Z"
+         id="path911"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sssssssssssss" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient965);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 341.12109,134.5 h -10.24218 c -4.49302,0 -6.796,0.397 -7.88868,1.48828 -1.09267,1.09128 -1.49023,3.39029 -1.49023,7.87891 v 8.26562 c 0,4.48861 0.39755,6.78763 1.49023,7.87891 1.09268,1.09128 3.39566,1.48828 7.88868,1.48828 h 10.24218 c 4.49303,0 6.796,-0.397 7.88868,-1.48828 1.09268,-1.09128 1.49023,-3.3903 1.49023,-7.87891 v -8.26562 c 0,-4.48862 -0.39756,-6.78763 -1.49023,-7.87891 C 347.91709,134.897 345.61412,134.5 341.12109,134.5 Z"
+         id="path955"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sscssssscssss" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1006);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 335.71484,190.5 h -7.43164 c -3.35788,0 -5.0105,0.31612 -5.73828,1.04297 -0.72778,0.72685 -1.04492,2.37787 -1.04492,5.73242 v 5.44922 c 0,3.35454 0.31714,5.00557 1.04492,5.73242 0.72778,0.72685 2.38235,1.04297 5.74024,1.04297 h 7.42968 c 3.35789,0 5.01246,-0.31612 5.74024,-1.04297 0.72778,-0.72685 1.04492,-2.37788 1.04492,-5.73242 v -5.44922 c 0,-3.35455 -0.31714,-5.00558 -1.04492,-5.73242 C 340.7273,190.81612 339.07273,190.5 335.71484,190.5 Z"
+         id="path974"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ssssssssssscs" />
+      <path
+         style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;font-variant-ligatures:normal;font-variant-position:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-alternates:normal;font-feature-settings:normal;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;writing-mode:lr-tb;direction:ltr;text-orientation:mixed;dominant-baseline:auto;baseline-shift:baseline;text-anchor:start;white-space:normal;shape-padding:0;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:0.5;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:url(#linearGradient1045);stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+         d="m 325.68945,237.5 h 4.6211 c 2.22275,0 3.22696,0.23524 3.58984,0.59766 0.36288,0.36241 0.59961,1.36547 0.59961,3.58593 v 3.63282 c 0,2.22046 -0.23673,3.22352 -0.59961,3.58593 -0.36288,0.36242 -1.36709,0.59766 -3.58984,0.59766 h -4.6211 c -2.22274,0 -3.22696,-0.23524 -3.58984,-0.59766 -0.36288,-0.36242 -0.59961,-1.36547 -0.59961,-3.58593 v -3.63282 c 0,-2.22046 0.23673,-3.22352 0.59961,-3.58593 0.36288,-0.36242 1.36709,-0.59766 3.58984,-0.59766 z"
+         id="path1035"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="sscsscssssscs" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer3"
+       inkscape:label="Highlights"
+       style="display:inline" />
+  </g>
+</svg>

--- a/src/symlinks/fullcolor/apps.list
+++ b/src/symlinks/fullcolor/apps.list
@@ -6,6 +6,7 @@ address-book-app.png office-address-book.png
 address-book-app.png office-addressbook.png
 address-book-app.png org.gnome.Contacts.png
 address-book-app.png x-office-address-book.png
+authenticator-app.png com.github.bilelmoussaoui.Authenticator.png 
 backups-app.png deja-dup.png
 backups-app.png org.gnome.DejaDup.png
 calculator-app.png accessories-calculator.png


### PR DESCRIPTION
New icon for GNOME Autheticator.
GNOME Autheticator is the new GNOME app for 2FA code generating: https://gitlab.gnome.org/World/Authenticator

![authenticator-app](https://user-images.githubusercontent.com/40228953/47651298-3d9ed280-db9c-11e8-946e-8266e9191e35.png)

Why precisely key? The application was created to create 2FA codes. Code is a key to web service.